### PR TITLE
Fix links due to moving www1 to www

### DIFF
--- a/docs/source/static/html/quicklinks.html
+++ b/docs/source/static/html/quicklinks.html
@@ -21,7 +21,7 @@
           <div id="searchbox3">
             <p class="highlight-link">
               <!-- Upcoming events -->
-              <a href="https://www1.hpc.kaust.edu.sa/event/events-calendar" class="btn btn-info p-2 text-white" target="_blank" >
+              <a href="https://www.hpc.kaust.edu.sa/event/events-calendar" class="btn btn-info p-2 text-white" target="_blank" >
                 <i class="fa-solid fa-calendar-days icon-before-text"></i>Upcoming events
               </a>
             </p>

--- a/docs/source/templates/_layout.html
+++ b/docs/source/templates/_layout.html
@@ -1,4 +1,4 @@
-<a class="user-documentation-2" target="_blank" href="https://www1.hpc.kaust.edu.sa/">
+<a class="user-documentation-2" target="_blank" href="https://www.hpc.kaust.edu.sa/">
     <div class="subtitle-2">HPC Portal</div>
     <img class="portal-img" src="../static/button-portal.svg">
 </a>


### PR DESCRIPTION
https://www1.hpc.kaust.edu.sa is moved to https://www.hpc.kaust.edu.sa so the links in the ksl-docs were broken. This PR aims to fix these links.