### PR TITLE
How to use NCO image

### DIFF
--- a/docs/source/soft_env/science_platforms/weather_climate/index.rst
+++ b/docs/source/soft_env/science_platforms/weather_climate/index.rst
@@ -19,3 +19,10 @@ The following recipes are available for building weather and climate software on
       wrf4.5.2
       wrf4.5.2-intel
 
+The list of software available on Shaheen III:
+
+.. toctree::
+      :titlesonly:
+      :maxdepth: 1
+
+      nco.rst

--- a/docs/source/soft_env/science_platforms/weather_climate/nco.rst
+++ b/docs/source/soft_env/science_platforms/weather_climate/nco.rst
@@ -1,0 +1,19 @@
+.. sectionauthor:: Kadir Akbudak <kadir.akbudak@kaust.edu.sa>
+.. meta::
+    :description: Using NCO on Shaheen III
+    :keywords: NCO
+
+====================================
+Using NCO on Shaheen III
+====================================
+
+The following SLURM job script file can be used to run NCO on Shaheen III:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --nodes=1
+    #SBATCH --hint=nomultithread
+    #SBATCH --time=00:10:00
+    module load singularity
+    singularity run /scratch/reference/singularity_images/atmospheric_oceanic_sciences/nco_4.8.1.sif nc-config --all

--- a/docs/source/soft_env/science_platforms/weather_climate/nco.rst
+++ b/docs/source/soft_env/science_platforms/weather_climate/nco.rst
@@ -16,4 +16,4 @@ The following SLURM job script file can be used to run NCO on Shaheen III:
     #SBATCH --hint=nomultithread
     #SBATCH --time=00:10:00
     module load singularity
-    singularity run /scratch/reference/singularity_images/atmospheric_oceanic_sciences/nco_4.8.1.sif nc-config --all
+    singularity run /scratch/reference/singularity_images/atmospheric_oceanic_sciences/nco_4.8.1.sif ncbo --version


### PR DESCRIPTION
This PR introduces documentation about how to use the NCO singularity image found under `/scratch/reference/singularity_images/atmospheric_oceanic_sciences` on Shaheen.