### PR TITLE
Fix typo on the rstudio.rst for singularity binds

### DIFF
--- a/docs/source/soft_env/job_schd/slurm/interactive_jobs/rstudio.rst
+++ b/docs/source/soft_env/job_schd/slurm/interactive_jobs/rstudio.rst
@@ -211,8 +211,8 @@ Submit the RStudio SLURM job script, for example, the following is a jobscript r
 
     chmod +x ${workdir}/rsession.sh
 
-    export SINGULARITY_BIND="${workdir}/run:/run,${workdir}/tmp:/tmp,${workdir}/database.conf:/etc/rstudio/database.conf,${workdir}/rsession.sh:/etc/rstudio/rsession.sh,${workdir}/var/lib/rstudio-server:/var/lib/rstudio-server,/sw:/sw,/ibex/sw:/ibex/sw:/ibex/user:/ibex/user"
-
+    export SINGULARITY_BIND="${workdir}/run:/run,${workdir}/tmp:/tmp,${workdir}/database.conf:/etc/rstudio/database.conf,${workdir}/rsession.sh:/etc/rstudio/rsession.sh,${workdir}/var/lib/rstudio-server:/var/lib/rstudio-server,/ibex/sw:/ibex/sw,/ibex/user:/ibex/user,/sw:/sw"
+ 
     # Do not suspend idle sessions.
     # Alternative to setting session-timeout-minutes=0 in /etc/rstudio/rsession.conf
     # https://github.com/rstudio/rstudio/blob/v1.4.1106/src/cpp/server/ServerSessionManager.cpp#L126

--- a/docs/source/soft_env/prog_env/python_package_management/conda/shaheen3.rst
+++ b/docs/source/soft_env/prog_env/python_package_management/conda/shaheen3.rst
@@ -40,7 +40,7 @@ Installing elaborate conda environments can be time consuming. To accelerate the
 
 .. code-block:: bash
   
-  conda install -y -c conda-forge mamba
+  conda install -y -c conda-forge mamba=1.5.8
   
 
 Creating new environments


### PR DESCRIPTION
Small typo on the submission script on the `export SINGULARITY_BIND`