### PR TITLE
Fix LHS TOC

### DIFF
--- a/docs/source/soft_env/job_schd/slurm/shaheen3_jobscript_examples.rst
+++ b/docs/source/soft_env/job_schd/slurm/shaheen3_jobscript_examples.rst
@@ -3,6 +3,7 @@
     :description: Example jobscripts
     :keywords: SLURM, MPI, OpenMP, GPU
 
+.. _shaheen3_example_jobscripts:
 
 ========================================================
 Shaheen III example jobscripts
@@ -10,7 +11,7 @@ Shaheen III example jobscripts
 This section provides a collection of jobscripts used to launch workload on Shaheen III. We always encourage users to contact :email:`Shaheen III support team<help@hpc.kaust.edu.sa>` for any cases not documented here.
 
 
-.. toctree:: 
+.. toctree::
     :maxdepth: 1
     :titlesonly:
 

--- a/docs/source/soft_env/prof_debug/profiling/nsight-systems/index.rst
+++ b/docs/source/soft_env/prof_debug/profiling/nsight-systems/index.rst
@@ -3,6 +3,7 @@
     :description: Nsight-systems
     :keywords: nsight
 
+.. _nsight_profiling:
 
 ###############
 Nsight Systems

--- a/docs/source/soft_env/science_platforms/data_science/index.rst
+++ b/docs/source/soft_env/science_platforms/data_science/index.rst
@@ -9,38 +9,33 @@
 Data Science platform
 ==============================
 
-Welcome to KSL's Data Science platform. 
+Welcome to KSL's Data Science platform.
 Here you will find the documentation on how to run Data Science and AI workloads on computational resources of KSL systems. The pages listed here walks you through from getting started on KSL systems, preparing your datasets, developing your models, and running the production jobs on multiple GPUs, and everything in between.
-The aim of this documentation is not to teach you Data Science by to focus on how to leverage KSL computational resources to increase the productivity in your workflows. 
+The aim of this documentation is not to teach you Data Science by to focus on how to leverage KSL computational resources to increase the productivity in your workflows.
 
 Getting started
 ================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
+:ref:`Getting started on Shaheen III <quickstart_shaheen3>`
 
-    Getting started on Shaheen III <../../../quickstart/shaheen3>
-    Getting started on Ibex <../../../quickstart/ibex>
+:ref:`Getting started on Ibex <quickstart_ibex_login>`
 
 Computational resources on KSL systems
 =======================================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
-    Shaheen III Login nodes <../../../systems/shaheen3/login_node>
-    Shaheen III Compute nodes <../../../systems/shaheen3/compute_node>
-    Ibex Login nodes <../../../systems/ibex/login_node>
-    Ibex Compute nodes <../../../systems/ibex/compute_node>
+
+:ref:`Shaheen III Login nodes <shaheen3_login_node>`
+
+:ref:`Shaheen III Compute nodes <shaheen3_compute_nodes>`
+
+:ref:`Ibex Login nodes <../../../systems/ibex/login_node>`
+
+:ref:`Ibex Compute nodes <../../../systems/ibex/compute_node>`
 
 Storage on KSL systems
 ========================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
     Shaheen III filesystems <../../../systems/shaheen3/filesystem>
     Ibex filesystems <../../../systems/ibex/filesystem>
@@ -48,9 +43,6 @@ Storage on KSL systems
 Running Jobs on KSL systems
 =======================================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
     SLURM jobscript explained <../../job_schd/basic_jobscript>
     Common SLURM commands <../../job_schd/slurm/commands>
@@ -63,21 +55,14 @@ Running Jobs on KSL systems
 Software environment
 =======================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
-    
+
     KSL managed software on Ibex for Data Science <ml_module_ibex>
     Self-managed software <../../prog_env/index>
     Portable software in containers <../../prog_env/containers/index>
-    
+
 
 Accelerating workloads
 =======================
-
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
 
     dist_mldl/index
@@ -86,9 +71,6 @@ Accelerating workloads
 Debugging and profiling
 =========================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
     In-flight job telemetry with NVDashboard <tools/nvdashboard>
     Profiling GPU workloads with NVIDIA Nsight <../../prof_debug/profiling/nsight-systems/index>
@@ -97,8 +79,6 @@ Debugging and profiling
 Miscellaneous
 =========================
 
-.. toctree::
-    :titlesonly:
-    :maxdepth: 1
 
     ollama/index
+

--- a/docs/source/soft_env/science_platforms/data_science/index.rst
+++ b/docs/source/soft_env/science_platforms/data_science/index.rst
@@ -29,26 +29,31 @@ Computational resources on KSL systems
 
 :ref:`Shaheen III Compute nodes <shaheen3_compute_nodes>`
 
-:ref:`Ibex Login nodes <../../../systems/ibex/login_node>`
+:ref:`Ibex Login nodes <ibex_login_nodes>`
 
-:ref:`Ibex Compute nodes <../../../systems/ibex/compute_node>`
+:ref:`Ibex Compute nodes <ibex_compute_nodes>`
 
 Storage on KSL systems
 ========================
 
 
-    Shaheen III filesystems <../../../systems/shaheen3/filesystem>
-    Ibex filesystems <../../../systems/ibex/filesystem>
+:ref:`Shaheen III filesystems <shaheen3_filesystem>`
+
+:ref:`Ibex filesystems <ibex_filesystems>`
 
 Running Jobs on KSL systems
 =======================================
 
 
-    SLURM jobscript explained <../../job_schd/basic_jobscript>
-    Common SLURM commands <../../job_schd/slurm/commands>
-    Running JupyterLab and VSCode <../../job_schd/slurm/interactive_jobs/index>
-    Shaheen III example jobscripts <../../job_schd/slurm/shaheen3_jobscript_examples>
-    Ibex example jobscripts <../../job_schd/slurm/ibex_jobscript_examples>
+:ref:`SLURM job script explained <slurm_jobscript>`
+
+:ref:`Common SLURM commands <slurm_commands>`
+
+:ref:`Running JupyterLab and VSCode <interactive_jobs>`
+
+:ref:`Shaheen III example job scripts <shaheen3_example_jobscripts>`
+
+:ref:`Ibex example job scripts <ibex_jobs_examples>`
 
 
 
@@ -56,29 +61,47 @@ Software environment
 =======================
 
 
-    KSL managed software on Ibex for Data Science <ml_module_ibex>
-    Self-managed software <../../prog_env/index>
-    Portable software in containers <../../prog_env/containers/index>
+.. toctree::
+       :titlesonly:
+       :maxdepth: 1
+
+       KSL managed software on Ibex for Data Science <ml_module_ibex>
+
+:ref:`Self-managed software <prog_env>`
+
+:ref:`Portable software in containers <container_platforms_guide>`
 
 
 Accelerating workloads
 =======================
 
 
-    dist_mldl/index
-    big_data_proc/index
+.. toctree::
+       :titlesonly:
+       :maxdepth: 1
+
+       dist_mldl/index
+       big_data_proc/index
 
 Debugging and profiling
 =========================
 
 
-    In-flight job telemetry with NVDashboard <tools/nvdashboard>
-    Profiling GPU workloads with NVIDIA Nsight <../../prof_debug/profiling/nsight-systems/index>
+.. toctree::
+       :titlesonly:
+       :maxdepth: 1
+
+       In-flight job telemetry with NVDashboard <tools/nvdashboard>
+
+:ref:`Profiling GPU workloads with NVIDIA Nsight <nsight_profiling>`
 
 
 Miscellaneous
 =========================
 
+.. toctree::
+       :titlesonly:
+       :maxdepth: 1
 
-    ollama/index
+       ollama/index
 


### PR DESCRIPTION
This PR fixes the issue reported in [this ticket](https://tickets.hpc.kaust.edu.sa/Ticket/Display.html?id=65406). The links in data science platform page are fixed properly. Previously, toc was used.