### PR TITLE
Turin nodes

### DIFF
--- a/docs/source/systems/ibex/compute_node.rst
+++ b/docs/source/systems/ibex/compute_node.rst
@@ -71,11 +71,11 @@ The table below summarizes the CPU nodes available in Ibex cluster. The values i
      - 744GB
    * - AMD Turin
      - Turin
-     - 53
+     - 50
      - 192
      - 2.60
      - 32
-     - 755GB  
+     - 708GB  
      - amd, turin
      - 1.7TB
 

--- a/docs/source/systems/ibex/compute_node.rst
+++ b/docs/source/systems/ibex/compute_node.rst
@@ -69,6 +69,15 @@ The table below summarizes the CPU nodes available in Ibex cluster. The values i
      - 475GB  
      - amd, rome
      - 744GB
+   * - AMD Turin
+     - Turin
+     - 53
+     - 192
+     - 2.60
+     - 32
+     - 755GB  
+     - amd, turin
+     - 1.7TB
 
 Some nodes have larger memory for workloads which require loading big data in memory, e.g. some bioinformatics workloads, or data processing/wrangling creating input data for Machine Learning and Deep Learning training jobs.   
 


### PR DESCRIPTION
50 new nodes are added to IBEX cluster. These nodes have AMD Turin CPUs. The documentation is requested in this [ticket](https://tickets.hpc.kaust.edu.sa/Ticket/Display.html?id=68212).